### PR TITLE
Build using maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# IntelliJ files
+*.iml
+
+# Build output
+target

--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # forked-test-measurements
 
 To run:
-1. Install instrumentation project, resulting jar goes to `$INST_JAR_LOC` (e.g. /Users/jon/.m2/repository/edu/gmu/swe/junit/measurement/BuildSystemProfiler/0.0.1-SNAPSHOT/BuildSystemProfiler-0.0.1-SNAPSHOT.jar)
-2. Set environmental variable `JAVA_TOOL_OPTIONS="-javaagent:$INST_JAR_LOC -Xbootclasspath/p:$INST_JAR_LOC`
-3. Run each build, collect output to file in `results/log.ant|mvn|gradle.txt`
-4. In `results` run `php parseLogs.php`
+
+1. Install instrumentation project
+
+```sh
+mvn clean install --file build-instrumenter/pom.xml
+```
+
+Look for `maven-install-plugin` command line output like
+
+    Installing /home/jon/code/dhis2/forked-test-measurements/build-instrumenter/target/build-system-profiler-1.0.0-SNAPSHOT-jar-with-dependencies.jar to /home/jon/.m2/repository/edu/gmu/swe/junit/measurement/build-system-profiler/1.0.0-SNAPSHOT/build-system-profiler-1.0.0-SNAPSHOT-jar-with-dependencies.jar
+
+which tells you where to the agent was installed
+
+2. Make the jar location available in an environment variable
+
+```sh
+export INST_JAR_LOC=<jar install destination>
+```
+
+**Make sure to use the location to the jar with-dependencies!**
+
+3. Set environmental variable
+
+```sh
+export JAVA_TOOL_OPTIONS="-javaagent:$INST_JAR_LOC -Xbootclasspath/a:$INST_JAR_LOC"
+```
+
+4. Run each build, collect output to file in `results/log.ant|mvn|gradle.txt`
+5. In `results` run `php parseLogs.php`
 
 Results:
 

--- a/build-instrumenter/pom.xml
+++ b/build-instrumenter/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>edu.gmu.swe.junit.measurement</groupId>
+    <artifactId>build-system-profiler</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>7.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Premain-Class>edu.gmu.swe.junit.measurement.Premain</Premain-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
It was not immediately obvious to me how to `Install instrumentation project`. I had to find the coordinates of the agent's dependency `org.ow2.asm`, decide which version to use. Build the agent including its dependency, make sure it has a manifest with then entry `Premain-Class`. `-Xbootclasspath/p` was also removed in one of the "recent" Java versions.

So I thought I contribute the changes I had to make to make it work back 😄 